### PR TITLE
feat: passport 적용 코드 작성

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
@@ -2,10 +2,12 @@ package com.yeoljeong.tripmate.filter;
 
 import com.yeoljeong.tripmate.error.GatewayErrorCode;
 import com.yeoljeong.tripmate.jwt.JwtProvider;
+import com.yeoljeong.tripmate.passport.PassportProvider;
 import com.yeoljeong.tripmate.properties.GatewayProperties;
 import com.yeoljeong.tripmate.response.GatewayResponseUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
@@ -15,14 +17,15 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
+@Slf4j
 @Component
 public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
-    private static final String HEADER_USER_ID = "X-User-Id";
-    private static final String HEADER_USER_ROLE = "X-User-Role";
+    private static final String HEADER_PASSPORT = "X-Passport";
 
     private final GatewayProperties gatewayProperties;
     private final JwtProvider jwtProvider;
+    private final PassportProvider passportProvider;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
@@ -30,7 +33,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         String path = exchange.getRequest().getURI().getPath();
         List<String> whitelist = gatewayProperties.getWhitelist();
 
-        if(isPublicPath(whitelist, path)){
+        if (isPublicPath(whitelist, path)) {
             return chain.filter(exchange);
         }
 
@@ -46,11 +49,13 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
         String userId = jwtProvider.getUserId(token);
         String role = jwtProvider.getRole(token);
+        String passport = passportProvider.issue(userId, role);
 
         ServerWebExchange mutatedExchange = exchange.mutate()
-                .request(r -> r.header(HEADER_USER_ID, userId)
-                        .header(HEADER_USER_ROLE, role))
-                .build();
+            .request(r -> r
+                .headers(headers -> headers.remove("X-Passport")) // 기존 헤더 제거
+                .header(HEADER_PASSPORT, passport))
+            .build();
 
         return chain.filter(mutatedExchange);
     }
@@ -63,6 +68,6 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     // helper method
     private boolean isPublicPath(List<String> whitelist, String path) {
         return whitelist.stream()
-                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+            .anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
@@ -53,7 +53,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
         ServerWebExchange mutatedExchange = exchange.mutate()
             .request(r -> r
-                .headers(headers -> headers.remove("X-Passport")) // 기존 헤더 제거
+                .headers(headers -> headers.remove(HEADER_PASSPORT)) // 기존 헤더 제거
                 .header(HEADER_PASSPORT, passport))
             .build();
 

--- a/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
@@ -49,15 +49,23 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
         String userId = jwtProvider.getUserId(token);
         String role = jwtProvider.getRole(token);
-        String passport = passportProvider.issue(userId, role);
 
-        ServerWebExchange mutatedExchange = exchange.mutate()
-            .request(r -> r
-                .headers(headers -> headers.remove(HEADER_PASSPORT)) // 기존 헤더 제거
-                .header(HEADER_PASSPORT, passport))
-            .build();
+        // issue에서 예외 발생시 Mono파이프라인 밖에서 500에러가 발생할 것을 방어
+        try {
+            String passport = passportProvider.issue(userId, role);
 
-        return chain.filter(mutatedExchange);
+            ServerWebExchange mutatedExchange = exchange.mutate()
+                .request(r -> r
+                    .headers(headers -> headers.remove(HEADER_PASSPORT))
+                    .header(HEADER_PASSPORT, passport))
+                .build();
+
+            return chain.filter(mutatedExchange);
+
+        } catch (Exception e) {
+            log.error("[Passport] 발급 실패 - userId: {}, error: {}", userId, e.getMessage());
+            return GatewayResponseUtil.writeErrorResponse(exchange, GatewayErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/passport/PassportProvider.java
+++ b/src/main/java/com/yeoljeong/tripmate/passport/PassportProvider.java
@@ -1,0 +1,32 @@
+package com.yeoljeong.tripmate.passport;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PassportProvider {
+
+    private static final long PASSPORT_EXPIRATION_MS = 30_000L;
+    private final SecretKey internalSecretKey;
+
+    public PassportProvider(@Value("${jwt.internal-secret}") String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.internalSecretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String issue(String userId, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+            .subject(userId)
+            .claim("role", role)
+            .issuedAt(now)
+            .expiration(new Date(now.getTime() + PASSPORT_EXPIRATION_MS))
+            .signWith(internalSecretKey)
+            .compact();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -90,3 +90,4 @@ gateway:
 
 jwt:
   secret: ${JWT_SECRET}
+  internal-secret: ${JWT_INTERNAL_SECRET}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- **서비스 간 신뢰 기반 인증을 위한 `Passport` 메커니즘 도입**
  - 게이트웨이에서 외부 JWT를 검증한 후, 내부 서비스(Downstream)로 요청을 보낼 때 게이트웨이가 보증하는 **내부 전용 인증 토큰(Passport)**을 발행하여 전달합니다.
  - 이를 통해 각 마이크로서비스는 별도의 복잡한 인증 로직 없이 게이트웨이가 발급한 Passport만으로 사용자 정보를 안전하게 신뢰할 수 있습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- **`PassportProvider` 신규 생성**: 
  - `userId`와 `role`을 페이로드로 하는 내부 전용 토큰 생성 로직 구현.
  - 내부 보안을 위해 외부 JWT와는 별도의 `internal-secret` 사용 및 **30초**의 짧은 만료 시간 설정.
- **`JwtAuthenticationFilter` 로직 고도화**:
  - JWT 검증 완료 후 `PassportProvider`를 통해 Passport를 발행하는 로직 추가.
  - **보안 강화**: 외부에서 주입될 수 있는 `X-Passport` 헤더를 명시적으로 제거(`remove`)한 뒤, 게이트웨이에서 생성한 신뢰 토큰을 주입하도록 `mutate()` 요청 흐름 개선.
- **설정 파일 업데이트**:
  - `application.yaml`에 Passport 서명용 `jwt.internal-secret` 프로퍼티 추가.

### background (or etc.) 
> 동료 개발자가 알아야할 사항
- **환경 변수 체크**: 로컬 환경 구동 시 `JWT_INTERNAL_SECRET` 환경 변수가 설정되어 있어야 Passport 정상 발행이 가능합니다.
- **보안 메커니즘**: 클라이언트가 임의의 `X-Passport`를 실어 보내더라도 게이트웨이 필터에서 강제로 초기화하므로 헤더 변조 공격에 대응되어 있습니다.
- **만료 시간 유의**: 현재 만료 시간이 30초로 설정되어 있습니다. 내부 서비스 간 네트워크 지연으로 인한 만료 이슈가 발생하는지 모니터링이 필요하며, 관련 의견 환영합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

**보안 개선**
- 인증 시스템 강화: 게이트웨이에 내부 보안 토큰 발급 메커니즘 도입
- 사용자 정보 전달 방식 개선: 직접 전달에서 암호화된 토큰 기반 방식으로 전환
- JWT 기반 내부 토큰 설정 추가 및 관련 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->