### PR TITLE
refact: Kafka Redis 메시지 직렬화 문제 처리 및 불필요한 import제거

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/config/ReactiveRedisConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/config/ReactiveRedisConfig.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class ReactiveRedisConfig {
+
+    @Bean
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
+        ReactiveRedisConnectionFactory factory) {
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+
+        RedisSerializationContext<String, String> context =
+            RedisSerializationContext.<String, String>newSerializationContext(serializer)
+                .value(serializer)
+                .build();
+
+        return new ReactiveRedisTemplate<>(factory, context);
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yeoljeong/tripmate/filter/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
@@ -26,6 +27,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     private final GatewayProperties gatewayProperties;
     private final JwtProvider jwtProvider;
     private final PassportProvider passportProvider;
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
@@ -50,22 +52,32 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         String userId = jwtProvider.getUserId(token);
         String role = jwtProvider.getRole(token);
 
-        // issue에서 예외 발생시 Mono파이프라인 밖에서 500에러가 발생할 것을 방어
-        try {
-            String passport = passportProvider.issue(userId, role);
+        return reactiveRedisTemplate.hasKey("BL:" + userId)
+            .flatMap(isBlackListed -> {
+                if (Boolean.TRUE.equals(isBlackListed)) {
+                    // 블랙리스트에 있으면 401
+                    return GatewayResponseUtil.writeErrorResponse(exchange,
+                        GatewayErrorCode.UNAUTHORIZED);
+                }
 
-            ServerWebExchange mutatedExchange = exchange.mutate()
-                .request(r -> r
-                    .headers(headers -> headers.remove(HEADER_PASSPORT))
-                    .header(HEADER_PASSPORT, passport))
-                .build();
+                // issue에서 예외 발생시 Mono파이프라인 밖에서 500에러가 발생할 것을 방어
+                try {
+                    String passport = passportProvider.issue(userId, role);
 
-            return chain.filter(mutatedExchange);
+                    ServerWebExchange mutatedExchange = exchange.mutate()
+                        .request(r -> r
+                            .headers(headers -> headers.remove(HEADER_PASSPORT))
+                            .header(HEADER_PASSPORT, passport))
+                        .build();
 
-        } catch (Exception e) {
-            log.error("[Passport] 발급 실패 - userId: {}, error: {}", userId, e.getMessage());
-            return GatewayResponseUtil.writeErrorResponse(exchange, GatewayErrorCode.INTERNAL_SERVER_ERROR);
-        }
+                    return chain.filter(mutatedExchange);
+
+                } catch (Exception e) {
+                    log.error("[Passport] 발급 실패 - userId: {}, error: {}", userId, e.getMessage());
+                    return GatewayResponseUtil.writeErrorResponse(exchange,
+                        GatewayErrorCode.INTERNAL_SERVER_ERROR);
+                }
+            });
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/jwt/JwtProvider.java
+++ b/src/main/java/com/yeoljeong/tripmate/jwt/JwtProvider.java
@@ -4,14 +4,13 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
-
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
 
 @Component
 @Slf4j

--- a/src/main/java/com/yeoljeong/tripmate/properties/GatewayProperties.java
+++ b/src/main/java/com/yeoljeong/tripmate/properties/GatewayProperties.java
@@ -1,10 +1,9 @@
 package com.yeoljeong.tripmate.properties;
 
+import java.util.List;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
-
-import java.util.List;
 
 @Getter
 @ConfigurationProperties(prefix = "gateway")

--- a/src/main/java/com/yeoljeong/tripmate/response/GatewayResponseUtil.java
+++ b/src/main/java/com/yeoljeong/tripmate/response/GatewayResponseUtil.java
@@ -1,10 +1,9 @@
 package com.yeoljeong.tripmate.response;
 
 import com.yeoljeong.tripmate.error.GatewayErrorCode;
+import java.nio.charset.StandardCharsets;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
-
-import java.nio.charset.StandardCharsets;
 
 public class GatewayResponseUtil {
 


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 로그아웃 처리된 토큰(Blacklist) 검증 로직을 `JwtAuthenticationFilter`에 추가하여 보안을 강화했습니다.
- 비동기 환경에 적합한 `ReactiveRedisTemplate`을 설정하고, 이를 필터 내에서 활용하여 Redis에 등록된 블랙리스트 토큰 여부를 확인합니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- **신규 설정 추가**: `ReactiveRedisConfig.java`를 생성하여 `ReactiveRedisTemplate<String, String>` 빈을 등록했습니다.
- **필터 로직 수정**: `JwtAuthenticationFilter.java`에서 Redis를 통해 블랙리스트(`BL:{userId}`) 여부를 조회하는 로직을 추가했습니다.
- **예외 처리 개선**: Passport 발급 시 발생할 수 있는 예외를 Mono 파이프라인 내(`flatMap`)로 옮겨, 런타임 에러 시 500 응답(`INTERNAL_SERVER_ERROR`)이 정상적으로 반환되도록 방어 로직을 구현했습니다.
- **코드 정리**: `JwtProvider`, `GatewayProperties` 등에서 불필요한 import 및 중복 라인을 제거하고 정렬했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- Redis에 블랙리스트 저장 시 키 포맷은 `BL:{userId}` 형식을 사용하고 있습니다. 
- 현재 로직은 토큰 자체를 검사하기보다 해당 유저가 블랙리스트 상태인지를 먼저 체크하는 방식이므로, 향후 "특정 토큰"만 만료시키는 로직으로 고도화가 필요할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증된 사용자의 토큰 무효화 상태를 확인하는 기능 추가

* **Chores**
  * 임포트 선언 순서 정렬

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/gateway-server/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->